### PR TITLE
Add fix eslint job

### DIFF
--- a/.github/workflows/fix-eslint.yml
+++ b/.github/workflows/fix-eslint.yml
@@ -1,0 +1,10 @@
+name: Fix eslint
+
+# Manually fix eslint/prettier issues on a branch without pulling locally.
+
+on:
+    workflow_dispatch:
+
+jobs:
+    fix-eslint:
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/fix-eslint.yml@main


### PR DESCRIPTION
Manually fix eslint/prettier issues on a branch without pulling locally. Useful after editing Changelog, docs or other text directly on GitHub, which often breaks eslint+prettier. Select the branch to fix via the native "Run workflow" branch picker. Protected branches are rejected at runtime.

Feel free to merge / close PR if not relevant for your workflow.